### PR TITLE
Dont assume php actually gives us the number of bytes we ask for

### DIFF
--- a/lib/audiostream.php
+++ b/lib/audiostream.php
@@ -147,7 +147,7 @@ class AudioStream {
 	            $data = fread($this->stream, $bytesToRead);
 	            echo $data;
 	            flush();
-	            $curPos += $bytesToRead;
+	            $curPos += strlen($data);
 	        }
 		}else{
 			 \OC\Files\Filesystem::readfile($this -> path);


### PR DESCRIPTION
When trying to read more then 8192 bytes from a stream php doesn't actually return the number of bytes requested but limits it to 8192 for all streams except native local streams ("historical reasons"...)

Thus you cant rely on php returning the correct number of bytes but need to check the return value of fread.

Fixes streaming of music when using locking, encryption or an external storage that supports streaming.

See https://bugs.php.net/bug.php?id=30936
