### PR TITLE
Fix issue #25: Null pointer exception while album list loads (Huge library)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -499,9 +499,13 @@ Audios.prototype.loadAlbums = function(){
 			 		divSongsContainer.append(listAlbumSelect);
 			 		
 			 		var aSongs=[];
-			 		$.each(songs[album.id],function(ii,songs){
-			 			aSongs[ii] = $this.loadSongsRow(songs, album.name);
-			 		});
+			 		if(songs[album.id]){
+				 		$.each(songs[album.id],function(ii,songs){
+				 			aSongs[ii] = $this.loadSongsRow(songs, album.name);
+				 		});
+			 		}else{
+			 			console.warn('Could not find songs for album:', album.name, album);
+			 		}
 			 		
 			 		listAlbumSelect.append(aSongs);
 			 		var br = $('<br />').css('clear','both');


### PR DESCRIPTION
Fixed null pointer exception while albums view is loading.
The songs array may lacks an entry for an album. This can break up the whole albums view.
